### PR TITLE
build(ci): generate route tree before typecheck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@tanstack/router-cli": "^1.141.7",
         "@types/node": "^24.10.1",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19.2.5",
@@ -4055,6 +4056,28 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/router-cli": {
+      "version": "1.141.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-cli/-/router-cli-1.141.7.tgz",
+      "integrity": "sha512-ki4C7P9A311SmdNYNifgZuSc+XEgxj+aT1VDQBRwXe9mVUa0lcGquEkkew1J42HDtzc1CjOmOYgAgPMsUfMLTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/router-generator": "1.141.7",
+        "chokidar": "^3.6.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "tsr": "bin/tsr.cjs"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/router-core": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "generate": "tsr generate",
+    "build": "tsr generate && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@tanstack/router-cli": "^1.141.7",
     "@types/node": "^24.10.1",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19.2.5",


### PR DESCRIPTION
CI builds failed because routeTree.gen.ts is not committed and tsc runs before the route tree is generated.

Changes:
- Add @tanstack/router-cli as a dev dependency
- Add a generate script (tsr generate)
- Run tsr generate before tsc in the build pipeline

Fixes: Netlify build exit code 2