### PR TITLE
fix: show previous year's review in January

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -196,7 +196,7 @@ function Dashboard() {
               className="gap-2 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-semibold px-8"
             >
               <Sparkles className="h-5 w-5" />
-              View {new Date().getFullYear()} Year in Review
+              View {new Date().getFullYear() - (new Date().getMonth() < 1 ? 1 : 0)} Year in Review
             </Button>
           </div>
         )}

--- a/src/routes/year-review.lazy.tsx
+++ b/src/routes/year-review.lazy.tsx
@@ -23,7 +23,9 @@ function YearReview() {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const navigate = useNavigate();
 
-  const year = new Date().getFullYear();
+  // Before February, show previous year's review
+  const now = new Date();
+  const year = now.getMonth() < 1 ? now.getFullYear() - 1 : now.getFullYear();
 
   // Fetch profile on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Year review now displays previous year's data when accessed in January
- Shows current year's data from February onwards

## Test plan
- [x] Test in January (or simulate by changing month check) to verify previous year is shown
- [x] Test in February or later to verify current year is shown