### PR TITLE
feat: add Cloudflare Pages deployment config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+name = "cptracker"
+compatibility_date = "2026-01-05"
+pages_build_output_dir = "dist"
+
+[assets]
+directory = "./dist"


### PR DESCRIPTION
## Summary
- Add `wrangler.toml` configuration file for Cloudflare Pages deployment
- Configures build output directory to `dist`

## Test plan
- [x] Verify wrangler.toml is valid
- [x] Test deployment to Cloudflare Pages