### PR TITLE
fix: preserve numeric string timestamps in date parser

### DIFF
--- a/src/services/date-service.ts
+++ b/src/services/date-service.ts
@@ -107,14 +107,23 @@ export function timestampToTimeOnly(timestamp: number): string {
  * @returns Unix 时间戳（毫秒）
  */
 export function legacyDateStringToTimestamp(dateStr: string): number {
+  const trimmed = dateStr.trim();
+
+  if (/^\d+$/.test(trimmed)) {
+    const numericValue = Number.parseInt(trimmed, 10);
+    if (isValidTimestamp(numericValue)) {
+      return numericValue;
+    }
+  }
+
   // Try parsing as-is first
-  const date = new Date(dateStr);
+  const date = new Date(trimmed);
   if (!isNaN(date.getTime())) {
     return date.getTime();
   }
 
   // Try replacing / with -
-  const normalized = dateStr.replace(/\//g, '-');
+  const normalized = trimmed.replace(/\//g, '-');
   const normalizedDate = new Date(normalized);
   if (!isNaN(normalizedDate.getTime())) {
     return normalizedDate.getTime();


### PR DESCRIPTION
## Summary
- treat pure numeric date strings as existing millisecond timestamps before legacy date parsing
- avoid falling back to the upload time when syncing/importing cloud problems
- keep the existing legacy date string parsing path for non-numeric inputs

## Test plan
- [x] npm run lint
- [x] npm run build