### PR TITLE
fix: preserve problem names during cloud sync

### DIFF
--- a/src/hooks/use-problems-queries.ts
+++ b/src/hooks/use-problems-queries.ts
@@ -189,6 +189,7 @@ export function useProblems() {
         await insertProblems(
           localProblems.map((p) => ({
             题目: p.题目,
+            题目名称: p.题目名称,
             难度: p.难度,
             题解: p.题解,
             关键词: p.关键词,
@@ -211,6 +212,7 @@ export function useProblems() {
         await dbImportProblems(
           cloudProblems.map((p) => ({
             题目: p.题目,
+            题目名称: p.题目名称,
             难度: p.难度,
             题解: p.题解,
             关键词: p.关键词,

--- a/src/lib/supabase/sync.ts
+++ b/src/lib/supabase/sync.ts
@@ -46,6 +46,7 @@ export async function pullFromCloud(): Promise<void> {
       // 云端数据存在于本地，更新本地数据
       await db.problems.update(localProblem.id, {
         题目: cloudProblem.题目,
+        题目名称: cloudProblem.题目名称,
         难度: cloudProblem.难度,
         题解: cloudProblem.题解,
         关键词: cloudProblem.关键词,
@@ -59,6 +60,7 @@ export async function pullFromCloud(): Promise<void> {
       // 云端有但本地没有，添加到本地
       await db.problems.add({
         题目: cloudProblem.题目,
+        题目名称: cloudProblem.题目名称,
         难度: cloudProblem.难度,
         题解: cloudProblem.题解,
         关键词: cloudProblem.关键词,
@@ -98,6 +100,7 @@ export async function pushToCloud(): Promise<void> {
           // 更新云端数据
           await updateProblemById(problem.supabase_id, {
             题目: problem.题目,
+            题目名称: problem.题目名称,
             难度: problem.难度,
             题解: problem.题解,
             关键词: problem.关键词,
@@ -107,6 +110,7 @@ export async function pushToCloud(): Promise<void> {
           // 新增到云端
           const cloudProblem = await insertRawProblem({
             题目: problem.题目,
+            题目名称: problem.题目名称,
             难度: problem.难度,
             题解: problem.题解,
             关键词: problem.关键词,
@@ -150,6 +154,7 @@ export async function initialUpload(): Promise<void> {
   const cloudProblems = await insertRawProblems(
     problemsToUpload.map((p) => ({
       题目: p.题目,
+      题目名称: p.题目名称,
       难度: p.难度,
       题解: p.题解,
       关键词: p.关键词,
@@ -179,6 +184,7 @@ export async function downloadFromCloud(): Promise<void> {
   // 导入云端数据
   const storedProblems: StoredProblem[] = cloudProblems.map((p) => ({
     题目: p.题目,
+    题目名称: p.题目名称,
     难度: p.难度,
     题解: p.题解,
     关键词: p.关键词,


### PR DESCRIPTION
## Summary
- preserve `题目名称` in local→cloud upload and cloud→local download flows
- preserve `题目名称` in incremental Supabase pull/push paths and initial upload/download helpers
- prevent the Name column from being cleared during cloud round-trips

## Test plan
- [x] npm run lint
- [x] npm run build
- [x] Upload local data to cloud and confirm the Name column is retained
- [x] Download cloud data to local and confirm the Name column is retained